### PR TITLE
skip span without parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ fiber-opentraing middleware support opentracing for [Fiber](https://github.com/g
 go get -u github.com/gofiber/v2
 go get -u github.com/aschenmaker/fiber-opentracing
 ```
-default use 
+default use
 ```go
 import (
 	"github.com/gofiber/fiber/v2"
@@ -20,10 +20,10 @@ app.Use(fibertracing.New())
 Middleware has 4 configs.
 ```go
 type Config struct {
-	Tracer           opentracing.Tracer
-	TransacationName func(*fiber.Ctx) string
-	Filter           func(*fiber.Ctx) bool
-	Modify           func(*fiber.Ctx, opentracing.Span)
+	Tracer        opentracing.Tracer
+	OperationName func(*fiber.Ctx) string
+	Filter        func(*fiber.Ctx) bool
+	Modify        func(*fiber.Ctx, opentracing.Span)
 }
 ```
 
@@ -46,13 +46,13 @@ import (
 func main() {
 	app := *fiber.New()
 	// Use jaeger default config.
-	// You can use Jaeger-all-in-one 
+	// You can use Jaeger-all-in-one
 	// and then check trace in JaegerUI
 	fjaeger.New(fjaeger.Config{})
 
 	app.Use(fibertracing.New(fibertracing.Config{
 		Tracer: opentracing.GlobalTracer(),
-		TransacationName: func(ctx *fiber.Ctx) string {
+		OperationName: func(ctx *fiber.Ctx) string {
 			return "TEST:  HTTP " + ctx.Method() + " URL: " + ctx.Path()
 		},
 	}))

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ app.Use(fibertracing.New())
 ```
 
 ## Config
-Middleware has 4 configs.
+Middleware has 5 configs.
 ```go
 type Config struct {
-	Tracer        opentracing.Tracer
-	OperationName func(*fiber.Ctx) string
-	Filter        func(*fiber.Ctx) bool
-	Modify        func(*fiber.Ctx, opentracing.Span)
+	Tracer                opentracing.Tracer
+	OperationName         func(*fiber.Ctx) string
+	Filter                func(*fiber.Ctx) bool
+	Modify                func(*fiber.Ctx, opentracing.Span)
+	SkipSpanWithoutParent bool
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -7,10 +7,10 @@ import (
 
 // Config defines the config of middlewares
 type Config struct {
-	Tracer           opentracing.Tracer
-	TransacationName func(*fiber.Ctx) string
-	Filter           func(*fiber.Ctx) bool
-	Modify           func(*fiber.Ctx, opentracing.Span)
+	Tracer        opentracing.Tracer
+	OperationName func(*fiber.Ctx) string
+	Filter        func(*fiber.Ctx) bool
+	Modify        func(*fiber.Ctx, opentracing.Span)
 }
 
 // ConfigDefault is the default config
@@ -23,7 +23,7 @@ var ConfigDefault = Config{
 		span.SetTag("http.host", ctx.Hostname())
 		span.SetTag("http.url", ctx.OriginalURL())
 	},
-	TransacationName: func(ctx *fiber.Ctx) string {
+	OperationName: func(ctx *fiber.Ctx) string {
 		return "HTTP " + ctx.Method() + " URL: " + ctx.Path()
 	},
 }
@@ -40,8 +40,8 @@ func configDefault(config ...Config) Config {
 		cfg.Tracer = ConfigDefault.Tracer
 	}
 
-	if cfg.TransacationName == nil {
-		cfg.TransacationName = ConfigDefault.TransacationName
+	if cfg.OperationName == nil {
+		cfg.OperationName = ConfigDefault.OperationName
 	}
 
 	if cfg.Modify == nil {

--- a/config.go
+++ b/config.go
@@ -7,10 +7,11 @@ import (
 
 // Config defines the config of middlewares
 type Config struct {
-	Tracer        opentracing.Tracer
-	OperationName func(*fiber.Ctx) string
-	Filter        func(*fiber.Ctx) bool
-	Modify        func(*fiber.Ctx, opentracing.Span)
+	Tracer                opentracing.Tracer
+	OperationName         func(*fiber.Ctx) string
+	Filter                func(*fiber.Ctx) bool
+	Modify                func(*fiber.Ctx, opentracing.Span)
+	SkipSpanWithoutParent bool
 }
 
 // ConfigDefault is the default config

--- a/example/example.go
+++ b/example/example.go
@@ -17,7 +17,7 @@ func main() {
 
 	app.Use(fibertracing.New(fibertracing.Config{
 		Tracer: opentracing.GlobalTracer(),
-		TransacationName: func(ctx *fiber.Ctx) string {
+		OperationName: func(ctx *fiber.Ctx) string {
 			return "TEST:  HTTP " + ctx.Method() + " URL: " + ctx.Path()
 		},
 	}))

--- a/trace.go
+++ b/trace.go
@@ -19,7 +19,7 @@ func New(config Config) fiber.Handler {
 		}
 		var span opentracing.Span
 
-		TransacationName := cfg.TransacationName(c)
+		operationName := cfg.OperationName(c)
 		tracer := cfg.Tracer
 		header := make(http.Header)
 
@@ -33,9 +33,9 @@ func New(config Config) fiber.Handler {
 		// Extract trace-id from header
 		sc, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(header))
 		if err == nil {
-			span = tracer.StartSpan(TransacationName, opentracing.ChildOf(sc))
+			span = tracer.StartSpan(operationName, opentracing.ChildOf(sc))
 		} else {
-			span = tracer.StartSpan(TransacationName)
+			span = tracer.StartSpan(operationName)
 		}
 
 		cfg.Modify(c, span)

--- a/trace.go
+++ b/trace.go
@@ -34,8 +34,10 @@ func New(config Config) fiber.Handler {
 		sc, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(header))
 		if err == nil {
 			span = tracer.StartSpan(operationName, opentracing.ChildOf(sc))
-		} else {
+		} else if !cfg.SkipSpanWithoutParent {
 			span = tracer.StartSpan(operationName)
+		} else {
+			return c.Next()
 		}
 
 		cfg.Modify(c, span)


### PR DESCRIPTION
- rename TransacationName to OperationName, as that's how opentracing refers to it
- add SkipSpanWithoutParent option, to not create span if no tracing headers present in the downstream request

Closes #3  