### PR TITLE
Share spanContext in fiber locals, to use on fiber handlers

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -34,9 +34,10 @@ func New(config Config) fiber.Handler {
 		sc, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(header))
 		if err == nil {
 			span = tracer.StartSpan(operationName, opentracing.ChildOf(sc))
-			c.Locals("spanContext", sc)
+			c.Locals("spanContext", span.Context())
 		} else if !cfg.SkipSpanWithoutParent {
 			span = tracer.StartSpan(operationName)
+			c.Locals("spanContext", span.Context())
 		} else {
 			return c.Next()
 		}

--- a/trace.go
+++ b/trace.go
@@ -34,14 +34,13 @@ func New(config Config) fiber.Handler {
 		sc, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(header))
 		if err == nil {
 			span = tracer.StartSpan(operationName, opentracing.ChildOf(sc))
-			c.Locals("spanContext", span.Context())
 		} else if !cfg.SkipSpanWithoutParent {
 			span = tracer.StartSpan(operationName)
-			c.Locals("spanContext", span.Context())
 		} else {
 			return c.Next()
 		}
 
+		c.Locals("spanContext", span.Context())
 		cfg.Modify(c, span)
 
 		defer func() {

--- a/trace.go
+++ b/trace.go
@@ -34,6 +34,7 @@ func New(config Config) fiber.Handler {
 		sc, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(header))
 		if err == nil {
 			span = tracer.StartSpan(operationName, opentracing.ChildOf(sc))
+			c.Locals("spanContext", sc)
 		} else if !cfg.SkipSpanWithoutParent {
 			span = tracer.StartSpan(operationName)
 		} else {


### PR DESCRIPTION
Add the spanContext generated in the middleware to the fiber c.Locals request map, and thus be able to use it in the different handlers and make these childrens of the spanContext.